### PR TITLE
Use AndroidX instead of support library

### DIFF
--- a/android/src/main/java/net/wowmaking/Utility.java
+++ b/android/src/main/java/net/wowmaking/Utility.java
@@ -6,7 +6,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.Matrix;
-import android.support.media.ExifInterface;
+import androidx.exifinterface.media.ExifInterface;
 import android.net.Uri;
 import android.os.Build;
 


### PR DESCRIPTION
The support library has been replaced by androidx.
https://developer.android.com/jetpack/androidx/migrate

I know turning on `android.useAndroidX` and `android.enableJetifier` should automatically convert third party librarys to use android x, but for this repo it wasn't the case.

It gaves the error:
```
/node_modules/react-native-image-tools-wm/android/src/main/java/net/wowmaking/Utility.java:9: error: package android.support.media does not exist
import android.support.media.ExifInterface;
                            ^
```

Given that whole android ecosystem & community has already adopted to use androidx, it's time to use android x flag correctly in all libraries as well. So I'm pulling this code change.